### PR TITLE
Allow musicbox to be deployed

### DIFF
--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -1,0 +1,8 @@
+resource "aws_ecr_repository" "musicbox" {
+  name                 = "musicbox"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/ecr/provider.tf
+++ b/ecr/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  shared_credentials_file = "$HOME/.aws/credentials"
+  profile                 = "default"
+  region                  = var.aws_region
+}

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_region" {
+  description = "The AWS region things are created in"
+  default     = "us-east-1"
+}

--- a/staging/alb.tf
+++ b/staging/alb.tf
@@ -1,0 +1,35 @@
+resource "aws_alb" "main" {
+  name            = "musicbox-load-balancer-staging"
+  subnets         = aws_subnet.public.*.id
+  security_groups = [aws_security_group.lb.id]
+}
+
+resource "aws_alb_target_group" "app" {
+  name        = "musicbox-target-group-staging"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.health_check_path
+    unhealthy_threshold = "2"
+  }
+}
+
+# Redirect all traffic from the ALB to the target group
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.id
+  port              = var.app_port
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.app.id
+    type             = "forward"
+  }
+}

--- a/staging/auto_scaling.tf
+++ b/staging/auto_scaling.tf
@@ -1,0 +1,88 @@
+resource "aws_appautoscaling_target" "target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  role_arn           = aws_iam_role.ecs_auto_scale_role.arn
+  min_capacity       = 1
+  max_capacity       = 2
+}
+
+# Automatically scale capacity up by one
+resource "aws_appautoscaling_policy" "up" {
+  name               = "musicbox_scale_up_staging"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+# Automatically scale capacity down by one
+resource "aws_appautoscaling_policy" "down" {
+  name               = "musicbox_scale_down_staging"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+# CloudWatch alarm that triggers the autoscaling up policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
+  alarm_name          = "musicbox_cpu_utilization_high_staging"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "85"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.main.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.up.arn]
+}
+
+# CloudWatch alarm that triggers the autoscaling down policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
+  alarm_name          = "musicbox_cpu_utilization_low_staging"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "10"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.main.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.down.arn]
+}

--- a/staging/ecs.tf
+++ b/staging/ecs.tf
@@ -1,0 +1,48 @@
+resource "aws_ecs_cluster" "main" {
+  name = "musicbox-cluster"
+}
+
+data "template_file" "musicbox_app" {
+  template = file("./templates/ecs/app.json.tpl")
+
+  vars = {
+    app_image      = var.app_image
+    app_port       = var.app_port
+    fargate_cpu    = var.fargate_cpu
+    fargate_memory = var.fargate_memory
+    aws_region     = var.aws_region
+    allowed_host   = aws_alb.main.dns_name
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "musicbox-app-task-staging"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = data.template_file.musicbox_app.rendered
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "musicbox-service-staging"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.app_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = aws_subnet.private.*.id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.app.id
+    container_name   = "musicbox-app-staging"
+    container_port   = var.app_port
+  }
+
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]
+}

--- a/staging/logs.tf
+++ b/staging/logs.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudwatch_log_group" "musicbox_log_group_staging" {
+  name              = "/ecs/musicbox-app-staging"
+  retention_in_days = 30
+
+  tags = {
+    Name = "musicbox-log-group-staging"
+  }
+}
+
+resource "aws_cloudwatch_log_stream" "musicbox_log_stream_staging" {
+  name           = "musicbox-log-stream-staging"
+  log_group_name = aws_cloudwatch_log_group.musicbox_log_group_staging.name
+}

--- a/staging/network.tf
+++ b/staging/network.tf
@@ -1,0 +1,66 @@
+data "aws_availability_zones" "available" {
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "172.17.0.0/16"
+}
+
+# Create var.az_count private subnets, each in a different AZ
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+}
+
+# Create var.az_count public subnets, each in a different AZ
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.az_count + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+}
+
+# Internet Gateway for the public subnet
+resource "aws_internet_gateway" "gw-staging" {
+  vpc_id = aws_vpc.main.id
+}
+
+# Route the public subnet traffic through the IGW
+resource "aws_route" "internet_access" {
+  route_table_id         = aws_vpc.main.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw-staging.id
+}
+
+# Create a NAT gateway with an Elastic IP for each private subnet to get internet connectivity
+resource "aws_eip" "gw-staging" {
+  count      = var.az_count
+  vpc        = true
+  depends_on = [aws_internet_gateway.gw-staging]
+}
+
+resource "aws_nat_gateway" "gw-staging" {
+  count         = var.az_count
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.gw-staging.*.id, count.index)
+}
+
+# Create a new route table for the private subnets, make it route non-local traffic through the NAT gateway to the internet
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.gw-staging.*.id, count.index)
+  }
+}
+
+# Explicitly associate the newly created route tables to the private subnets (so they don't default to the main route table)
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+}

--- a/staging/outputs.tf
+++ b/staging/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_hostname" {
+  value = aws_alb.main.dns_name
+}

--- a/staging/provider.tf
+++ b/staging/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  shared_credentials_file = "$HOME/.aws/credentials"
+  profile                 = "default"
+  region                  = var.aws_region
+}

--- a/staging/roles.tf
+++ b/staging/roles.tf
@@ -1,0 +1,37 @@
+# ECS task execution role data
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# ECS task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = var.ecs_task_execution_role_name
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+# ECS task execution role policy attachment
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_auto_scale_role" {
+  name               = var.ecs_auto_scale_role_name
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+# ECS task execution role policy attachment
+resource "aws_iam_role_policy_attachment" "ecs_auto_scale_role" {
+  role       = aws_iam_role.ecs_auto_scale_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/staging/security.tf
+++ b/staging/security.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "lb" {
+  name        = "musicbox-load-balancer-security-group"
+  description = "controls access to the ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.app_port
+    to_port     = var.app_port
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Traffic to the ECS cluster should only come from the ALB
+resource "aws_security_group" "ecs_tasks" {
+  name        = "musicbox-ecs-tasks-security-group-staging"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.app_port
+    to_port         = var.app_port
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/staging/templates/ecs/app.json.tpl
+++ b/staging/templates/ecs/app.json.tpl
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "musicbox-app-staging",
+    "image": "${app_image}",
+    "cpu": ${fargate_cpu},
+    "memory": ${fargate_memory},
+    "networkMode": "awsvpc",
+    "environment": [
+      { "name": "ALLOWED_HOST", "value": "${allowed_host}" }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/musicbox-app-staging",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port}
+      }
+    ]
+  }
+]

--- a/staging/variables.tf
+++ b/staging/variables.tf
@@ -1,0 +1,48 @@
+variable "aws_region" {
+  description = "The AWS region things are created in"
+  default     = "us-east-1"
+}
+
+variable "ecs_task_execution_role_name" {
+  description = "ECS task execution role name"
+  default     = "MusicboxECSTaskExecutionRole"
+}
+
+variable "ecs_auto_scale_role_name" {
+  description = "ECS auto scale role Name"
+  default     = "MusicboxECSAutoScaleRole"
+}
+
+variable "az_count" {
+  description = "Number of AZs to cover in a given region"
+  default     = "2"
+}
+
+variable "app_image" {
+  description = "Docker image to run in the ECS cluster"
+  default     = "593337084109.dkr.ecr.us-east-1.amazonaws.com/musicbox:latest"
+}
+
+variable "app_port" {
+  description = "Port exposed by the docker image to redirect traffic to"
+  default     = 3000
+}
+
+variable "app_count" {
+  description = "Number of docker containers to run"
+  default     = 1
+}
+
+variable "health_check_path" {
+  default = "/"
+}
+
+variable "fargate_cpu" {
+  description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
+  default     = "1024"
+}
+
+variable "fargate_memory" {
+  description = "Fargate instance memory to provision (in MiB)"
+  default     = "2048"
+}


### PR DESCRIPTION
@go-between/folks 

Allows for an ECR thing to be created so that we can push up images.  Sets up the rest of everything so that we can deploy to ECS.  Borrows heavily from https://medium.com/@bradford_hamilton/deploying-containers-on-amazons-ecs-using-fargate-and-terraform-part-2-2e6f6a3a957fa.  The database connection does not yet work because there is no database.  Or redis.  Or anything.