### PR TITLE
Allow the ecs task to connect to the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.tfstate
 *.tfstate.*
 
+# .tfvars
+*.tfvars
+*.tfvars.*
+
 # Crash log files
 crash.log
 

--- a/staging/app/database.tf
+++ b/staging/app/database.tf
@@ -11,8 +11,10 @@ resource "aws_db_instance" "musicbox-staging" {
   engine_version         = "11.5"
   instance_class         = "db.t2.micro"
   name                   = "musicbox"
-  username               = "read_write"
-  password               = "PleaseReplaceMePlease!"
+  username               = "root"
+  password               = var.db_root_password_staging
   vpc_security_group_ids = [aws_security_group.db-staging.id]
   db_subnet_group_name   = aws_db_subnet_group.staging.name
+  publicly_accessible    = true
+  skip_final_snapshot    = true
 }

--- a/staging/app/ecs.tf
+++ b/staging/app/ecs.tf
@@ -6,13 +6,17 @@ data "template_file" "musicbox-app" {
   template = file("./templates/ecs/app.json.tpl")
 
   vars = {
-    app_image      = var.app_image
-    app_port       = var.app_port
-    fargate_cpu    = var.fargate_cpu
-    fargate_memory = var.fargate_memory
-    aws_region     = var.aws_region
-    allowed_host   = aws_alb.staging.dns_name
+    app_image       = var.app_image
+    app_port        = var.app_port
+    fargate_cpu     = var.fargate_cpu
+    fargate_memory  = var.fargate_memory
+    aws_region      = var.aws_region
+    allowed_host    = aws_alb.staging.dns_name
+    database_url    = "postgresql://root:${var.db_root_password_staging}@${aws_db_instance.musicbox-staging.address}"
+    secret_key_base = var.secret_key_base_staging
   }
+
+  depends_on = [aws_db_instance.musicbox-staging]
 }
 
 resource "aws_ecs_task_definition" "staging" {

--- a/staging/app/network.tf
+++ b/staging/app/network.tf
@@ -2,7 +2,8 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "staging" {
-  cidr_block = "172.17.0.0/16"
+  cidr_block           = "172.17.0.0/16"
+  enable_dns_hostnames = true
 }
 data "aws_vpc" "staging" {
   default = true

--- a/staging/app/templates/ecs/app.json.tpl
+++ b/staging/app/templates/ecs/app.json.tpl
@@ -2,12 +2,15 @@
   {
     "name": "musicbox-app-staging",
     "image": "${app_image}",
+    "command": ["passenger", "start", "-p", "80"],
     "cpu": ${fargate_cpu},
     "memory": ${fargate_memory},
     "networkMode": "awsvpc",
     "environment": [
       { "name": "ALLOWED_HOST", "value": "${allowed_host}" },
-      { "name": "RAILS_ENV", "value": "staging" }
+      { "name": "DATABASE_URL", "value": "${database_url}" },
+      { "name": "RAILS_ENV", "value": "staging" },
+      { "name": "SECRET_KEY_BASE", "value": "${secret_key_base}" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/staging/app/variables.tf
+++ b/staging/app/variables.tf
@@ -1,3 +1,6 @@
+variable "db_root_password_staging" {}
+variable "secret_key_base_staging" {}
+
 variable "aws_region" {
   description = "The AWS region things are created in"
   default     = "us-east-1"
@@ -25,7 +28,7 @@ variable "app_image" {
 
 variable "app_port" {
   description = "Port exposed by the docker image to redirect traffic to"
-  default     = 3000
+  default     = 80
 }
 
 variable "app_count" {
@@ -34,7 +37,7 @@ variable "app_count" {
 }
 
 variable "health_check_path" {
-  default = "/"
+  default = "/health_check"
 }
 
 variable "fargate_cpu" {


### PR DESCRIPTION
@go-between/folks 

Adds a connection string from the ECS task to the database and tries to make the database publicly accessible.  Changes the healthcheck endpoint to `/health_check`, and establishes the old terraform.tfvars pattern for secret keeping.

The database connection is working!
<img width="2019" alt="Screen Shot 2020-01-28 at 6 33 06 PM" src="https://user-images.githubusercontent.com/59452077/73318002-b193b480-41fd-11ea-98fd-d0688210482d.png">
But we gotta figure out how to get in to the db so that we can create the database.
<img width="1253" alt="Screen Shot 2020-01-28 at 6 37 30 PM" src="https://user-images.githubusercontent.com/59452077/73318021-bfe1d080-41fd-11ea-839e-d865ba807578.png">
