### PR TITLE
Allow database to be created and migrations to be run

### DIFF
--- a/staging/app/database.tf
+++ b/staging/app/database.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "musicbox-staging" {
   engine                 = "postgres"
   engine_version         = "11.5"
   instance_class         = "db.t2.micro"
-  name                   = "musicbox"
+  name                   = "postgres"
   username               = "root"
   password               = var.db_root_password_staging
   vpc_security_group_ids = [aws_security_group.db-staging.id]

--- a/staging/app/db_tasks.tf
+++ b/staging/app/db_tasks.tf
@@ -1,0 +1,53 @@
+data "template_file" "musicbox-app-db-create" {
+  template = file("./templates/ecs/db-create.json.tpl")
+
+  vars = {
+    app_image       = var.app_image
+    app_port        = var.app_port
+    fargate_cpu     = var.fargate_cpu
+    fargate_memory  = var.fargate_memory
+    aws_region      = var.aws_region
+    allowed_host    = aws_alb.staging.dns_name
+    database_url    = "postgresql://root:${var.db_root_password_staging}@${aws_db_instance.musicbox-staging.address}"
+    secret_key_base = var.secret_key_base_staging
+  }
+
+  depends_on = [aws_db_instance.musicbox-staging]
+}
+
+resource "aws_ecs_task_definition" "staging-db-create" {
+  family                   = "musicbox-app-task-staging-db-create"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = data.template_file.musicbox-app-db-create.rendered
+}
+
+data "template_file" "musicbox-app-db-migrate" {
+  template = file("./templates/ecs/db-migrate.json.tpl")
+
+  vars = {
+    app_image       = var.app_image
+    app_port        = var.app_port
+    fargate_cpu     = var.fargate_cpu
+    fargate_memory  = var.fargate_memory
+    aws_region      = var.aws_region
+    allowed_host    = aws_alb.staging.dns_name
+    database_url    = "postgresql://root:${var.db_root_password_staging}@${aws_db_instance.musicbox-staging.address}"
+    secret_key_base = var.secret_key_base_staging
+  }
+
+  depends_on = [aws_db_instance.musicbox-staging]
+}
+
+resource "aws_ecs_task_definition" "staging-db-migrate" {
+  family                   = "musicbox-app-task-staging-db-migrate"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = data.template_file.musicbox-app-db-migrate.rendered
+}

--- a/staging/app/templates/ecs/db-create.json.tpl
+++ b/staging/app/templates/ecs/db-create.json.tpl
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "musicbox-app-staging",
+    "image": "${app_image}",
+    "command": ["bin/rake", "db:create"],
+    "cpu": ${fargate_cpu},
+    "memory": ${fargate_memory},
+    "networkMode": "awsvpc",
+    "environment": [
+      { "name": "ALLOWED_HOST", "value": "${allowed_host}" },
+      { "name": "DATABASE_URL", "value": "${database_url}" },
+      { "name": "RAILS_ENV", "value": "staging" },
+      { "name": "SECRET_KEY_BASE", "value": "${secret_key_base}" }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/musicbox-app-staging",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port}
+      }
+    ]
+  }
+]

--- a/staging/app/templates/ecs/db-migrate.json.tpl
+++ b/staging/app/templates/ecs/db-migrate.json.tpl
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "musicbox-app-staging",
+    "image": "${app_image}",
+    "command": ["bin/rake", "db:migrate"],
+    "cpu": ${fargate_cpu},
+    "memory": ${fargate_memory},
+    "networkMode": "awsvpc",
+    "environment": [
+      { "name": "ALLOWED_HOST", "value": "${allowed_host}" },
+      { "name": "DATABASE_URL", "value": "${database_url}" },
+      { "name": "RAILS_ENV", "value": "staging" },
+      { "name": "SECRET_KEY_BASE", "value": "${secret_key_base}" }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/musicbox-app-staging",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port}
+      }
+    ]
+  }
+]


### PR DESCRIPTION
@go-between/folks 

Adds task definitions for one-off tasks to run db create, db migrate via
```
aws2 ecs run-task --cluster musicbox-cluster-staging --task-definition musicbox-app-task-staging-db-create --count 1 --launch-type FARGATE --network-configuration "awsvpcConfiguration={subnets=[SUBNETS_BLAH_BLAH],securityGroups=[SECURITY_GROUPS_BLAH_BLAH]}"
```