### PR TITLE
Cost reduction

### DIFF
--- a/staging/app/alb.tf
+++ b/staging/app/alb.tf
@@ -25,9 +25,11 @@ resource "aws_alb_target_group" "staging" {
 # Redirect all traffic from the ALB to the target group
 resource "aws_alb_listener" "front-end-staging" {
   load_balancer_arn = aws_alb.staging.id
-  port              = var.app_port
-  protocol          = "HTTP"
-
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  # Made manually in AWS
+  certificate_arn = "arn:aws:acm:us-east-1:593337084109:certificate/ae733b80-9348-4c20-a4a9-aef871ba1a37"
   default_action {
     target_group_arn = aws_alb_target_group.staging.id
     type             = "forward"

--- a/staging/app/ecs.tf
+++ b/staging/app/ecs.tf
@@ -12,7 +12,7 @@ data "template_file" "musicbox-app" {
     fargate_memory  = var.fargate_memory
     aws_region      = var.aws_region
     command         = jsonencode(["passenger", "start", "-p", "80"])
-    allowed_hosts   = "^172\\\\.17\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}$&^${aws_alb.staging.dns_name}$"
+    allowed_hosts   = "^172\\\\.17\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}$&^${aws_alb.staging.dns_name}$&^api-staging.musicbox.fm$"
     database_url    = "postgresql://root:${var.db_root_password_staging}@${aws_db_instance.musicbox-staging.address}"
     secret_key_base = var.secret_key_base_staging
     redis_url       = "redis://${aws_elasticache_cluster.musicbox-staging.cache_nodes.0.address}:6379"
@@ -39,7 +39,7 @@ resource "aws_ecs_service" "staging" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs-tasks-staging.id]
+    security_groups  = [aws_security_group.ecs-tasks-staging.id, aws_security_group.ecs-ecr-staging.id]
     subnets          = aws_subnet.private-staging.*.id
     assign_public_ip = false
   }

--- a/staging/app/network.tf
+++ b/staging/app/network.tf
@@ -42,10 +42,13 @@ resource "aws_eip" "gw-staging" {
   depends_on = [aws_internet_gateway.gw-staging]
 }
 
-resource "aws_nat_gateway" "gw-staging" {
-  count         = var.az_count
-  subnet_id     = element(aws_subnet.public-staging.*.id, count.index)
-  allocation_id = element(aws_eip.gw-staging.*.id, count.index)
+resource "aws_instance" "nat-gateway-staging" {
+  count = var.az_count
+
+  ami               = "${var.nat_vpc_ami}"
+  instance_type     = "t2.micro"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  subnet_id         = element(aws_subnet.public-staging.*.id, count.index)
 }
 
 # Create a new route table for the private subnets, make it route non-local traffic through the NAT gateway to the internet

--- a/staging/app/outputs.tf
+++ b/staging/app/outputs.tf
@@ -1,3 +1,15 @@
 output "alb_hostname" {
   value = aws_alb.staging.dns_name
 }
+
+output "aws_security_group-ecs-tasks-staging" {
+  value = aws_security_group.ecs-tasks-staging.id
+}
+
+output "aws_security_group-ecs-ecr-staging" {
+  value = aws_security_group.ecs-ecr-staging.id
+}
+
+output "aws_subnet_private-staging_ids" {
+  value = aws_subnet.private-staging.*.id
+}

--- a/staging/app/security.tf
+++ b/staging/app/security.tf
@@ -39,6 +39,27 @@ resource "aws_security_group" "ecs-tasks-staging" {
   }
 }
 
+resource "aws_security_group" "ecs-ecr-staging" {
+  name        = "musicbox-ecs-ecr-security-group-staging"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = aws_vpc.staging.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
 # Traffic to the DB should only come from the ECS Task security group
 resource "aws_security_group" "db-staging" {
   name   = "musicbox-db-security-group-staging"

--- a/staging/app/security.tf
+++ b/staging/app/security.tf
@@ -5,8 +5,8 @@ resource "aws_security_group" "lb-staging" {
 
   ingress {
     protocol    = "tcp"
-    from_port   = var.app_port
-    to_port     = var.app_port
+    from_port   = 443
+    to_port     = 443
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/staging/app/sidekiq.tf
+++ b/staging/app/sidekiq.tf
@@ -39,7 +39,7 @@ resource "aws_ecs_service" "sidekiq-staging" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs-tasks-staging.id]
+    security_groups  = [aws_security_group.ecs-tasks-staging.id, aws_security_group.ecs-ecr-staging.id]
     subnets          = aws_subnet.private-staging.*.id
     assign_public_ip = true
   }

--- a/staging/app/tasks.tf
+++ b/staging/app/tasks.tf
@@ -39,7 +39,7 @@ resource "aws_ecs_service" "room-poll-staging" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs-tasks-staging.id]
+    security_groups  = [aws_security_group.ecs-tasks-staging.id, aws_security_group.ecs-ecr-staging.id]
     subnets          = aws_subnet.private-staging.*.id
     assign_public_ip = true
   }

--- a/staging/app/variables.tf
+++ b/staging/app/variables.tf
@@ -52,10 +52,10 @@ variable "health_check_path" {
 
 variable "fargate_cpu" {
   description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
-  default     = "1024"
+  default     = "256"
 }
 
 variable "fargate_memory" {
   description = "Fargate instance memory to provision (in MiB)"
-  default     = "2048"
+  default     = "512"
 }

--- a/staging/app/variables.tf
+++ b/staging/app/variables.tf
@@ -36,6 +36,11 @@ variable "app_count" {
   default     = 1
 }
 
+variable "nat_vpc_ami" {
+  description = "amzn-ami-vpc-nat-hvm-2018.03.0.20180811-x86_64-ebs AMI"
+  default     = "ami-0422d936d535c63b1"
+}
+
 variable "worker_count" {
   description = "Number of docker containers to run"
   default     = 1


### PR DESCRIPTION
@go-between/folks 

Holy shit aws.  Alright, attempts to replace the nat gateways with an EC2 instance.  I don't think this actually worked, but it did force me to create VPC endpoints to ECR (where our docker images are stored), S3 (to store docker image layers), ECS (to communicate with our containers) and Cloudwatch (to log/monitor).  VPC endpoints are super dope because they mean that all traffic stays _inside_ of AWS, meaning we don't traverse the public internet to do things like fetch docker images.  This all should save us on running costs.

I also made the deployed ecs containers as small as possible, which should save a bit more.

Finally, I attached our newly-validated SSL certificate to the load balancer and told it to listen on 443. 

<img width="554" alt="Screen Shot 2020-02-12 at 1 57 25 AM" src="https://user-images.githubusercontent.com/59452077/74314632-5e604c80-4d3b-11ea-8e9c-009e1e7f86e6.png">

_This is the most beautiful lock icon I've ever seen._

Still to-do:
  - Actually fix NAT so that our services can talk to the outside world sometimes (to fetch youtube data, send emails, etc.)
  - Monitor AWS spend to make sure we really have dropped cost
  - ???????????? finish integrating web app with our new backend