### PR TITLE
Allow port forwarding over SSM instance

### DIFF
--- a/staging/app/auto_scaling.tf
+++ b/staging/app/auto_scaling.tf
@@ -2,7 +2,6 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.staging.name}/${aws_ecs_service.staging.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = aws_iam_role.ecs_auto_scale_role.arn
   min_capacity       = 1
   max_capacity       = 1
 }

--- a/staging/app/network.tf
+++ b/staging/app/network.tf
@@ -45,6 +45,7 @@ resource "aws_instance" "nat-gateway-staging" {
   subnet_id              = element(aws_subnet.public-staging.*.id, count.index)
   vpc_security_group_ids = [aws_security_group.nat-gateway-staging.id]
   source_dest_check      = false
+  iam_instance_profile   = "AmazonSSMRoleForInstancesQuickSetup"
 }
 
 # Create a new route table for the private subnets, make it route non-local traffic through the NAT gateway to the internet

--- a/staging/app/outputs.tf
+++ b/staging/app/outputs.tf
@@ -13,3 +13,7 @@ output "aws_security_group-ecs-ecr-staging" {
 output "aws_subnet_private-staging_ids" {
   value = aws_subnet.private-staging.*.id
 }
+
+output "aws_db_instance-staging-address" {
+  value = aws_db_instance.musicbox-staging.address
+}

--- a/staging/app/roles.tf
+++ b/staging/app/roles.tf
@@ -24,14 +24,3 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
-
-resource "aws_iam_role" "ecs_auto_scale_role" {
-  name               = var.ecs_auto_scale_role_name
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
-}
-
-# ECS task execution role policy attachment
-resource "aws_iam_role_policy_attachment" "ecs_auto_scale_role" {
-  role       = aws_iam_role.ecs_auto_scale_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}

--- a/staging/app/session_manager.tf
+++ b/staging/app/session_manager.tf
@@ -9,6 +9,12 @@ resource "aws_instance" "ssm-staging" {
   tags = {
     Name = "SSM-Staging"
   }
+
+  user_data = <<-EOF
+    #! /bin/bash
+    yum install -y ec2-instance-connect
+    yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  EOF
 }
 
 # VPC Endpoint
@@ -97,6 +103,10 @@ data "aws_iam_policy_document" "assume_role_policy" {
   }
 }
 
+data "aws_iam_policy" "ssm-staging" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
 resource "aws_iam_policy" "ssm-staging" {
   name   = "ssm-staging"
   policy = data.aws_iam_policy.ssm-staging.policy
@@ -108,6 +118,4 @@ resource "aws_iam_role_policy_attachment" "ssm-staging" {
   policy_arn = aws_iam_policy.ssm-staging.arn
 }
 
-data "aws_iam_policy" "ssm-staging" {
-  arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
-}
+

--- a/staging/app/sidekiq.tf
+++ b/staging/app/sidekiq.tf
@@ -52,7 +52,6 @@ resource "aws_appautoscaling_target" "sidekiq-target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.sidekiq-staging.name}/${aws_ecs_service.sidekiq-staging.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = aws_iam_role.ecs_auto_scale_role.arn
   min_capacity       = 1
   max_capacity       = 1
 }

--- a/staging/app/tasks.tf
+++ b/staging/app/tasks.tf
@@ -52,7 +52,6 @@ resource "aws_appautoscaling_target" "room-poll-staging" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.tasks-staging.name}/${aws_ecs_service.room-poll-staging.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = aws_iam_role.ecs_auto_scale_role.arn
   min_capacity       = 1
   max_capacity       = 1
 

--- a/staging/app/users.tf
+++ b/staging/app/users.tf
@@ -1,0 +1,24 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "ssm-ssh-management-staging" {
+  statement {
+    actions = [
+      "ec2-instance-connect:SendSSHPublicKey"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${aws_instance.ssm-staging.id}"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ssm-ssh-management-staging" {
+  name   = "ssm-ssh-management-staging"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ssm-ssh-management-staging.json
+}
+
+resource "aws_iam_policy_attachment" "ssm-ssh-management-staging" {
+  name       = "ssm-ssh-management-staging"
+  users      = ["musicbox-truman"]
+  policy_arn = aws_iam_policy.ssm-ssh-management-staging.arn
+}


### PR DESCRIPTION
@go-between/folks 

Adds some things to allow port forwarding over the SSM instance we use -- allows us to connect to the RDS instance even though it's HIDING in our vpc.  Also cleans up a few properties that kept wiggling when applying terraforms, and adds the database address to the outputs