### PR TITLE
More ecs memory

### DIFF
--- a/staging/app/ecs.tf
+++ b/staging/app/ecs.tf
@@ -11,7 +11,7 @@ data "template_file" "musicbox-app" {
     fargate_cpu              = var.fargate_cpu
     fargate_memory           = "1024"
     aws_region               = var.aws_region
-    command                  = jsonencode(["passenger", "start", "-p", "80"])
+    command                  = jsonencode(["passenger", "start", "-p", "80", "--nginx-config-template", "nginx.conf.erb"])
     allowed_hosts            = "^172\\\\.17\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}$&^${aws_alb.staging.dns_name}$&^api-staging.musicbox.fm$&^https://musicbox.fm$"
     database_url             = "postgresql://root:${var.db_root_password_staging}@${aws_db_instance.musicbox-staging.address}"
     log_level                = "error"

--- a/staging/app/ecs.tf
+++ b/staging/app/ecs.tf
@@ -9,7 +9,7 @@ data "template_file" "musicbox-app" {
     app_image                = var.app_image
     app_port                 = var.app_port
     fargate_cpu              = var.fargate_cpu
-    fargate_memory           = var.fargate_memory
+    fargate_memory           = "1024"
     aws_region               = var.aws_region
     command                  = jsonencode(["passenger", "start", "-p", "80"])
     allowed_hosts            = "^172\\\\.17\\\\.\\\\d{1,3}\\\\.\\\\d{1,3}$&^${aws_alb.staging.dns_name}$&^api-staging.musicbox.fm$&^https://musicbox.fm$"
@@ -33,7 +33,7 @@ resource "aws_ecs_task_definition" "staging" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_cpu
-  memory                   = var.fargate_memory
+  memory                   = "1024"
   container_definitions    = data.template_file.musicbox-app.rendered
 }
 


### PR DESCRIPTION
@go-between/folks 

We were basically always running up against the upper limit of our (very small) 512mb web tasks.  Memory is reasonably cheap so let's give ourselves some breathing room.  We also update the passenger command to make use of our custom nginx config.

Hopefully one or both of these help with random disconnects!