### PR TITLE
Turn off skylight

### DIFF
--- a/staging/app/ecs.tf
+++ b/staging/app/ecs.tf
@@ -20,8 +20,8 @@ data "template_file" "musicbox-app" {
     redis_url                = "redis://${aws_elasticache_cluster.musicbox-staging.cache_nodes.0.address}:6379"
     sidekiq_redis_url        = "redis://${aws_elasticache_cluster.musicbox-sidekiq-staging.cache_nodes.0.address}:6379"
     skylight_auth            = var.skylight_auth
-    skylight_enabled         = true
-    skylight_sidekiq_enabled = true
+    skylight_enabled         = false
+    skylight_sidekiq_enabled = false
   }
 
   depends_on = [aws_db_instance.musicbox-staging, aws_elasticache_cluster.musicbox-staging]

--- a/staging/app/sidekiq.tf
+++ b/staging/app/sidekiq.tf
@@ -20,8 +20,8 @@ data "template_file" "musicbox-sidekiq" {
     redis_url                = "redis://${aws_elasticache_cluster.musicbox-staging.cache_nodes.0.address}:6379"
     sidekiq_redis_url        = "redis://${aws_elasticache_cluster.musicbox-sidekiq-staging.cache_nodes.0.address}:6379"
     skylight_auth            = var.skylight_auth
-    skylight_enabled         = true
-    skylight_sidekiq_enabled = true
+    skylight_enabled         = false
+    skylight_sidekiq_enabled = false
   }
 
   depends_on = [aws_db_instance.musicbox-staging, aws_elasticache_cluster.musicbox-staging]


### PR DESCRIPTION
@go-between/folks 

We're near the end of our free trial. Skylight remains incredibly dope, but we're not ready to use it to optimize stuff yet.  So we'll disable it to save $20/mo or whatever until then.